### PR TITLE
Issue #28 feat(Database): Configure Liquibase for Bank API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ server:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://localhost:8765/eureka
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/bank_db

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,19 @@
+server:
+  port: 8081
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/bank_db
+    username: postgres
+    password: 12345
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 spring:
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: dev
+    active: test
   application:
        name: Bank-Api

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,58 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+
+    <changeSet id="create_user_role_enum" author="muhammad hussein" context="development">
+        <sql>
+            CREATE TYPE user_role AS ENUM ('CUSTOMER', 'ADMIN');
+        </sql>
+    </changeSet>
+
+    <changeSet id="create__transaction_enum" author="muhammad hussein">
+        <sql>
+            CREATE TYPE transaction_type_enum AS ENUM ('DEPOSIT', 'WITHDRAWAL');
+        </sql>
+    </changeSet>
+
+    <changeSet id="create__user_status_enum" author="muhammad hussein" context="development">
+        <sql>
+            CREATE TYPE user_status_enum AS ENUM ('ACTIVE', 'INACTIVE', 'SUSPENDED');
+        </sql>
+    </changeSet>
+
+    <changeSet id="create__account_status_enum" author="muhammad hussein" context="development">
+        <sql>
+            CREATE TYPE account_status_enum AS ENUM ('ACTIVE', 'INACTIVE', 'CLOSED');
+        </sql>
+    </changeSet>
+
+    <changeSet id="create_users_tbl" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="users"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/users_v.0.0.0.sql"/>
+    </changeSet>
+
+    <changeSet id="create_accounts_tbl" author="muhammad hussein">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="accounts"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/accounts_v.0.0.1.sql"/>
+    </changeSet>
+
+    <changeSet id="create_transactions_tbl" author="muhammad hussein">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="transactions"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/transactions_v.0.0.2.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/accounts_v.0.0.1.sql
+++ b/src/main/resources/db/changelog/sql/accounts_v.0.0.1.sql
@@ -1,0 +1,10 @@
+CREATE TABLE accounts (
+    account_id BIGSERIAL PRIMARY KEY,
+    card_number VARCHAR(20) UNIQUE NOT NULL,
+    cvv VARCHAR(4) NOT NULL,
+    balance NUMERIC(15,2) NOT NULL CHECK (balance >= 0),
+    account_status account_status_enum NOT NULL DEFAULT 'ACTIVE',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    user_id BIGINT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/changelog/sql/transactions_v.0.0.2.sql
+++ b/src/main/resources/db/changelog/sql/transactions_v.0.0.2.sql
@@ -1,0 +1,9 @@
+CREATE TABLE transactions (
+    transaction_id BIGSERIAL PRIMARY KEY,
+    transaction_type transaction_type_enum NOT NULL,
+    transaction_amount NUMERIC(15,2) NOT NULL CHECK (transaction_amount > 0),
+    transaction_note TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    account_id BIGINT NOT NULL,
+    FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/changelog/sql/users_v.0.0.0.sql
+++ b/src/main/resources/db/changelog/sql/users_v.0.0.0.sql
@@ -1,0 +1,14 @@
+CREATE TABLE users (
+    username VARCHAR(255) UNIQUE NOT NULL,
+    user_id BIGSERIAL PRIMARY KEY,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    phone_number VARCHAR(20) NOT NULL CHECK (phone_number ~ '^\+?[0-9]{10,20}$'
+    ),
+    user_address TEXT NOT NULL,
+    user_status user_status_enum NOT NULL DEFAULT 'ACTIVE',
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role user_role NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
Closed #28

This PR introduces Liquibase changesets to manage database schema changes. It includes the creation of enum types and tables for the application.

Changes Included:
Added Enum Types:

user_role: Defines user roles (CUSTOMER, ADMIN).

transaction_type_enum: Defines transaction types (DEPOSIT, WITHDRAWAL).

user_status_enum: Defines user statuses (ACTIVE, INACTIVE, SUSPENDED).

account_status_enum: Defines account statuses (ACTIVE, INACTIVE, CLOSED).

Created Tables:

users: Table for storing user information.

accounts: Table for storing account information.

transactions: Table for storing transaction information.

Preconditions:

Added preconditions to ensure changesets are only executed if the tables do not already exist.

Testing:
Verified that the enum types and tables are created successfully in the database.


