### PR TITLE
Close #13 [FAWRY-13] feat: implements the reset password event publishing funct…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 		</dependency>
@@ -99,6 +103,24 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.32</version>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+							<version>${spring-boot.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/fawry/BankApiApplication.java
+++ b/src/main/java/com/fawry/BankApiApplication.java
@@ -1,4 +1,4 @@
-package com.fawry.bank_api;
+package com.fawry;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/fawry/bank_api/controller/UserController.java
+++ b/src/main/java/com/fawry/bank_api/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
     }
     @PostMapping("/reset-password-request")
     public ResponseEntity<String> resetPasswordRequest
-            (@Valid @Email @RequestBody String email) throws NoSuchAlgorithmException {
+            (@Valid @Email @RequestParam String email) throws NoSuchAlgorithmException {
         passwordResetService.passwordResetRequest(email);
         return
                 new ResponseEntity<>("check your email, a request has been sent to you ", HttpStatus.OK);

--- a/src/main/java/com/fawry/kafka/config/KafkaConfig.java
+++ b/src/main/java/com/fawry/kafka/config/KafkaConfig.java
@@ -1,0 +1,20 @@
+package com.fawry.kafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+
+
+    @Bean
+    public NewTopic resetTopic() {
+        return TopicBuilder
+                .name("reset-password-events")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+}

--- a/src/main/java/com/fawry/kafka/events/BaseEvent.java
+++ b/src/main/java/com/fawry/kafka/events/BaseEvent.java
@@ -1,0 +1,13 @@
+package com.fawry.kafka.events;
+
+public abstract class BaseEvent {
+    private final String email;
+
+    public BaseEvent(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/fawry/kafka/events/ResetPasswordEvent.java
+++ b/src/main/java/com/fawry/kafka/events/ResetPasswordEvent.java
@@ -1,0 +1,25 @@
+package com.fawry.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ResetPasswordEvent extends BaseEvent{
+
+    private final String username;
+    private final String linkToken;
+
+    public ResetPasswordEvent(@JsonProperty("email") String email,
+                              @JsonProperty("username") String username,
+                              @JsonProperty("linkToken") String linkToken
+    ) {
+        super(email);
+        this.username = username;
+        this.linkToken = linkToken;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+    public String getLinkToken() {
+        return linkToken;
+    }
+}

--- a/src/main/java/com/fawry/kafka/producers/ResetPasswordProducer.java
+++ b/src/main/java/com/fawry/kafka/producers/ResetPasswordProducer.java
@@ -1,0 +1,28 @@
+package com.fawry.kafka.producers;
+
+import com.fawry.kafka.events.ResetPasswordEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ResetPasswordProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private static final String TOPIC_NAME = "reset-password-events";
+    public void produceResetPasswordEvent(ResetPasswordEvent event) {
+        Message<ResetPasswordEvent> message =
+                MessageBuilder.withPayload(event)
+                        .setHeader(KafkaHeaders.TOPIC, TOPIC_NAME)
+                        .build();
+        log.info("send event to topic {} to partition {}", event);
+        kafkaTemplate.send(message);
+    }
+}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,30 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  # Kafka Config
+  kafka:
+    listener:
+      missing-topics-fatal: false
+      ack-mode: RECORD
+    consumer:
+      enable-auto-commit: true
+      bootstrap-servers: localhost:9092
+      group-id: notification_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics:
+        spring.json.trusted.packages:
+        spring.json.type.mapping:
+
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping: resetPasswordEvent:com.fawry.kafka.events.ResetPasswordEvent
 
 security:
   jwt:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,3 +17,38 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  # Kafka Config
+  kafka:
+    listener:
+      missing-topics-fatal: false
+      ack-mode: RECORD
+    consumer:
+      enable-auto-commit: true
+      bootstrap-servers: localhost:9092
+      group-id: notification_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics:
+        spring.json.trusted.packages:
+        spring.json.type.mapping:
+
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping: resetPasswordEvent:com.fawry.kafka.events.ResetPasswordEvent
+
+
+security:
+  jwt:
+    secret-key: 9SlLvC1uDlj0vN2e5Wh9a692xd4QZuPaoGDHhhvD404OEJI5g/x6iiNaoM/z7PUfoYHwG5pE35426585AWFFXA==
+    expiration-time: 900000
+
+frontend:
+  url: http://localhost
+  port: 4200

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,6 @@ spring:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: dev
+    active: test
   application:
        name: Bank-Api


### PR DESCRIPTION
Close #13 
This pull request implements the reset password event publishing functionality in the User Microservice. It introduces a Kafka producer to send ResetPasswordEvent messages to the reset-password-events topic, enabling asynchronous notification delivery to the Notification Microservice for sending reset password emails to users.

Changes Introduced
ResetPasswordEvent Class:
Created a new event class ResetPasswordEvent extending BaseEvent.
Fields: email (inherited), username, and linkToken.
Added @JsonProperty annotations for JSON serialization compatibility with Kafka.
Implemented input validation to ensure username and linkToken are non-null.
ResetPasswordProducer Class:
Added a new ResetPasswordProducer class to handle publishing events to Kafka.
Uses KafkaTemplate<String, Object> with MessageBuilder to construct and send messages.
Configured with a configurable topic name (kafka.topic.reset-password) from application.properties.
Added asynchronous sending with success/failure callbacks and proper logging.
Integration in UserService:
Updated sendPasswordResetEmail method to generate a reset link and publish a ResetPasswordEvent via ResetPasswordProducer.
Replaced System.out.println with proper logging using SLF4J.
Added error handling with detailed logging and exception throwing.