### PR TITLE
[FAWRY-17] feat: Enhance Payment Cancellation Saga in Payment Service

### DIFF
--- a/src/main/java/com/fawry/bank_api/controller/TransactionController.java
+++ b/src/main/java/com/fawry/bank_api/controller/TransactionController.java
@@ -19,11 +19,11 @@ public class TransactionController {
 
     @PostMapping("/deposit")
     public ResponseEntity<TransactionDetailsResponse> deposit(@Valid @RequestBody DepositRequest request) {
-        return ResponseEntity.ok(transactionService.deposit(request));
+        return ResponseEntity.ok(transactionService.deposit(request, 0L));
     }
 
     @PostMapping("/withdraw")
     public ResponseEntity<TransactionDetailsResponse> withdraw(@Valid @RequestBody WithdrawRequest request) {
-        return ResponseEntity.ok(transactionService.withdraw(request));
+        return ResponseEntity.ok(transactionService.withdraw(request, 0L));
     }
 }

--- a/src/main/java/com/fawry/bank_api/dto/transaction/TransactionState.java
+++ b/src/main/java/com/fawry/bank_api/dto/transaction/TransactionState.java
@@ -1,0 +1,6 @@
+package com.fawry.bank_api.dto.transaction;
+
+public enum TransactionState {
+    CREATED,
+    CANCELED
+}

--- a/src/main/java/com/fawry/bank_api/entity/Transaction.java
+++ b/src/main/java/com/fawry/bank_api/entity/Transaction.java
@@ -1,5 +1,6 @@
 package com.fawry.bank_api.entity;
 
+import com.fawry.bank_api.dto.transaction.TransactionState;
 import com.fawry.bank_api.enums.TransactionType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
@@ -11,6 +12,8 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+
+import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @Table(name = "transactions")
@@ -29,10 +32,17 @@ public class Transaction {
     @JoinColumn(name = "account_id", nullable = false)
     private Account account;
 
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
     @NotNull(message = "Transaction type is required")
-    @Enumerated(EnumType.STRING)
+    @Enumerated(STRING)
     @Column(name = "transaction_type",nullable = false)
     private TransactionType type;
+
+    @Enumerated(STRING)
+    @Column(name = "state", nullable = false)
+    private TransactionState state;
 
     @Size(max = 1000, message = "Transaction note cannot exceed 1000 characters")
     @Column(name = "note", columnDefinition = "TEXT")

--- a/src/main/java/com/fawry/bank_api/repository/TransactionRepository.java
+++ b/src/main/java/com/fawry/bank_api/repository/TransactionRepository.java
@@ -3,6 +3,8 @@ package com.fawry.bank_api.repository;
 import com.fawry.bank_api.entity.Account;
 import com.fawry.bank_api.entity.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +12,13 @@ import java.util.List;
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
     List<Transaction> findByAccountOrderByCreatedAtDesc(Account account);
+
+    @Query(value = """
+            select * from transactions
+            where transaction_id in (
+            	select transaction_id from transactions
+            	where order_id = :orderId
+            )
+            """, nativeQuery = true)
+    List<Transaction> findOrderTransactionByOrderId(@Param("orderId") Long orderId);
 }

--- a/src/main/java/com/fawry/bank_api/service/TransactionService.java
+++ b/src/main/java/com/fawry/bank_api/service/TransactionService.java
@@ -7,6 +7,6 @@ import com.fawry.kafka.events.StoreCreatedEventDTO;
 
 public interface TransactionService {
     void makePayment(StoreCreatedEventDTO orderRequest);
-    TransactionDetailsResponse deposit(DepositRequest depositRequest);
-    TransactionDetailsResponse withdraw(WithdrawRequest withdrawRequest);
+    TransactionDetailsResponse deposit(DepositRequest depositRequest, Long orderId);
+    TransactionDetailsResponse withdraw(WithdrawRequest withdrawRequest, Long orderId);
 }

--- a/src/main/java/com/fawry/kafka/events/OrderCanceledEventDTO.java
+++ b/src/main/java/com/fawry/kafka/events/OrderCanceledEventDTO.java
@@ -1,25 +1,20 @@
 package com.fawry.kafka.events;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.io.Serializable;
 
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Setter
+@Builder
 @ToString
 public class OrderCanceledEventDTO implements Serializable {
 
-    private final Long orderId;
-    private final String reason;
-    private final String customerEmail;
-
-
-
-    public static OrderCanceledEventDTO newInstance(Long orderId, String reason, String customerEmail) {
-        return new OrderCanceledEventDTO(orderId, reason, customerEmail);
-    }
+    private Long orderId;
+    private String reason;
+    private String customerEmail;
 
 }
 

--- a/src/main/java/com/fawry/kafka/producers/PaymentCreatedPublisher.java
+++ b/src/main/java/com/fawry/kafka/producers/PaymentCreatedPublisher.java
@@ -23,6 +23,5 @@ public class PaymentCreatedPublisher {
                         .setHeader(TOPIC, "payment-created-events")
                         .build();
         kafkaTemplate.send(message);
-
     }
 }

--- a/src/main/java/com/fawry/shipping_api/kafka/events/OrderCanceledEventDTO.java
+++ b/src/main/java/com/fawry/shipping_api/kafka/events/OrderCanceledEventDTO.java
@@ -1,0 +1,4 @@
+package com.fawry.shipping_api.kafka.events;
+
+public class OrderCanceledEventDTO {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -27,14 +27,16 @@ spring:
     consumer:
       enable-auto-commit: true
       bootstrap-servers: localhost:9092
-      group-id: notification_id
+      group-id: bank_store_id, bank_shipping_id
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
-        allow.auto.create.topics:
-        spring.json.trusted.packages:
+        allow.auto.create.topics: true
+        spring.json.trusted.packages: "com.fawry.kafka.events"
         spring.json.type.mapping:
+          storeCreatedEventDTO:com.fawry.kafka.events.StoreCreatedEventDTO,
+          orderCanceledEventDTO:com.fawry.kafka.events.OrderCanceledEventDTO
 
     producer:
       bootstrap-servers: localhost:9092
@@ -42,7 +44,8 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.add.type.headers: true
-        spring.json.type.mapping: resetPasswordEvent:com.fawry.kafka.events.ResetPasswordEvent
+        spring.json.type.mapping: paymentCreatedEventDTO:com.fawry.kafka.events.PaymentCreatedEventDTO, orderCanceledEventDTO:com.fawry.kafka.events.OrderCanceledEventDTO, resetPasswordEvent:com.fawry.kafka.events.ResetPasswordEvent
+
 
 security:
   jwt:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,7 +12,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -26,14 +26,16 @@ spring:
     consumer:
       enable-auto-commit: true
       bootstrap-servers: localhost:9092
-      group-id: bank_store_id
+      group-id: bank_store_id, bank_shipping_id
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         allow.auto.create.topics: true
         spring.json.trusted.packages: "com.fawry.kafka.events"
-        spring.json.type.mapping: storeCreatedEventDTO:com.fawry.kafka.events.StoreCreatedEventDTO
+        spring.json.type.mapping:
+         storeCreatedEventDTO:com.fawry.kafka.events.StoreCreatedEventDTO,
+         orderCanceledEventDTO:com.fawry.kafka.events.OrderCanceledEventDTO
 
     producer:
       bootstrap-servers: localhost:9092

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,6 @@ spring:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: test
+    active: dev
   application:
        name: Bank-Api

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -54,5 +54,30 @@
         <sqlFile path="db/changelog/sql/password_change_requests_v.0.0.0.sql"/>
     </changeSet>
 
+    <changeSet id="order_id_column" author="Muhammad Hussein" context="development">
+        <preConditions>
+            <not>
+                <columnExists tableName="transactions" columnName="order_id"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/order_id_column_v.0.1.1.sql"/>
+    </changeSet>
+
+    <changeSet id="create_transaction_state_enum" author="Muhammad Hussein" context="development">
+        <sqlFile path="db/changelog/sql/transaction_state_enum_v.1.1.1.sql"/>
+    </changeSet>
+
+    <changeSet id="create_transaction_state_enum_column" author="Muhammad Hussein" context="development">
+        <preConditions>
+            <not>
+                <columnExists tableName="transactions" columnName="state"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/transaction_state_column_v.1.1.2.sql"/>
+    </changeSet>
+
+    <changeSet id="update_transaction_state_enum" author="Muhammad Hussein" context="development">
+        <sqlFile path="db/changelog/sql/update_state_type_v.1.2.2.sql"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/order_id_column_v.0.1.1.sql
+++ b/src/main/resources/db/changelog/sql/order_id_column_v.0.1.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transactions
+ADD COLUMN order_id BIGINT;

--- a/src/main/resources/db/changelog/sql/transaction_state_column_v.1.1.2.sql
+++ b/src/main/resources/db/changelog/sql/transaction_state_column_v.1.1.2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE transactions
+ADD COLUMN state transaction_state NOT NULL DEFAULT 'CREATED';
+

--- a/src/main/resources/db/changelog/sql/transaction_state_enum_v.1.1.1.sql
+++ b/src/main/resources/db/changelog/sql/transaction_state_enum_v.1.1.1.sql
@@ -1,0 +1,1 @@
+CREATE TYPE transaction_state AS ENUM ('CREATED', 'CANCELED');

--- a/src/main/resources/db/changelog/sql/update_state_type_v.1.2.2.sql
+++ b/src/main/resources/db/changelog/sql/update_state_type_v.1.2.2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ALTER COLUMN state TYPE VARCHAR;


### PR DESCRIPTION
This PR enhances the Payment Cancellation Saga in the Payment Service. The Payment Service now properly reverses WITHDRAW and DEPOSIT transactions when handling OrderCanceledEventDTO from the shipping-canceled-events topic. The transaction amount is set to 0, and the state is updated to CANCELED. A new PaymentCanceledEventDTO is published to the payment-canceled-events topic to continue the Saga flow, avoiding potential loops. The implementation includes better logging, error handling, and validation for transaction types. All operations are atomic using @Transactional.

Changes:
Updated PaymentCancellationService to handle OrderCanceledEventDTO:
Validates transaction types (WITHDRAW and DEPOSIT) explicitly.
Sets transaction amount to BigDecimal.ZERO and state to CANCELED.
Adds better logging and error handling.
Added PaymentCancellationPublisher to publish PaymentCanceledEventDTO to payment-canceled-events topic.
Used @Transactional to ensure atomicity.